### PR TITLE
Fix registration removal

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -1,5 +1,8 @@
 exports.AugustPlatform = void 0;
 
+const ModuleName = "homebridge-august-smart-locks"
+const PlatformName = "AugustLocks"
+
 const AugustApi = function(config) {
     process.env.AUGUST_API_KEY = config.securityToken || "7cab4bbd-2693-4fc1-b99b-dec0fb20f9d4"; //pulled from android apk july 2020
     process.env.AUGUST_INSTALLID = config.installId;
@@ -19,7 +22,7 @@ class AugustPlatform {
       this.Characteristic = api.hap.Characteristic;
       this.UUIDGen = api.hap.uuid;
   
-      this.config = config || { "platform": "AugustLocks" };
+      this.config = config || { "platform": PlatformName };
       this.email = this.config.email;
       this.phone = this.config.phone;
       this.password = this.config.password;
@@ -100,7 +103,7 @@ class AugustPlatform {
       if (accessory) {
         var deviceID = accessory.context.deviceID;
         accessory.context.log("Removed from HomeBridge.");
-        this.api.unregisterPlatformAccessories("homebridge-AugustLock2", "AugustLock2", [accessory]);
+        this.api.unregisterPlatformAccessories(ModuleName, PlatformName, [accessory]);
         delete this.accessories[deviceID];
   
       }
@@ -414,7 +417,7 @@ class AugustPlatform {
           self.setService(newAccessory);
           // Register accessory in HomeKit
           self.platformLog("adding lock lock to homebridge");
-          self.api.registerPlatformAccessories("homebridge-august-smart-locks", "AugustLocks", [newAccessory]);
+          self.api.registerPlatformAccessories(ModuleName, PlatformName, [newAccessory]);
   
         } else {
           // Retrieve accessory from cache

--- a/platform.js
+++ b/platform.js
@@ -170,6 +170,26 @@ class AugustPlatform {
   
     }
   
+    // Method to set target lock state
+    setState(accessory, state, callback) {
+      var self = this;
+  
+      // Always re-login for setting the state
+      this.getDevice(function (getlocksError) {
+        if (!getlocksError) {
+          self.setState(accessory, state, function (setStateError) {
+            callback(setStateError);
+          });
+  
+        } else {
+          callback(getlocksError);
+  
+        }
+  
+      }, accessory.context.deviceID);
+  
+    }
+  
     // Method to get target lock state
     getState(accessory, callback) {
       // Get target state directly from cache


### PR DESCRIPTION
The module names and platform names were inconsistently used. So move them all to constants so they can be updated in one location