### PR TITLE
Remove stale set state

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -491,9 +491,8 @@ class AugustPlatform {
       var self = this;
       var lockCtx = accessory.context;
       var status = this.lockState[state];
-      var augustState = (state == self.Characteristic.LockTargetState.SECURED) ? this.augustApi.lock(lockCtx.deviceID) : this.augustApi.unlock(lockCtx.deviceID);
+      var remoteOperate = (state == self.Characteristic.LockTargetState.SECURED) ? this.augustApi.lock(lockCtx.deviceID) : this.augustApi.unlock(lockCtx.deviceID);
   
-      var remoteOperate = this.augustApi.lock(lockCtx.deviceID);
       remoteOperate.then(function (result) {
         lockCtx.log("State was successfully set to " + status);
   

--- a/platform.js
+++ b/platform.js
@@ -167,26 +167,6 @@ class AugustPlatform {
   
     }
   
-    // Method to set target lock state
-    setState(accessory, state, callback) {
-      var self = this;
-  
-      // Always re-login for setting the state
-      this.getDevice(function (getlocksError) {
-        if (!getlocksError) {
-          self.setState(accessory, state, function (setStateError) {
-            callback(setStateError);
-          });
-  
-        } else {
-          callback(getlocksError);
-  
-        }
-  
-      }, accessory.context.deviceID);
-  
-    }
-  
     // Method to get target lock state
     getState(accessory, callback) {
       // Get target state directly from cache


### PR DESCRIPTION
- `setState()` method that was being shadowed. Removed the unused version. 
- Fixed setState() when you unlock the door, it would end up locking the door immediately afterwards. 