### PR TITLE
Fix Lock Target State characteristic error

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -539,7 +539,7 @@ class AugustPlatform {
         self.count = 0;
         self.periodicUpdate();
         accessory.context.currentState = state;
-        callback(null, state);
+        callback(null);
         setImmediate(() => {
           self.updatelockStates(accessory);
         });


### PR DESCRIPTION
Remove state from setState callback to fix "Characteristic 'Lock Target State': SET handler returned write response value, though the characteristic doesn't support write response." in Homebridge.

```
[8/1/2021, 10:34:07 AM] [AugustLocks] [August Front Door] State was successfully set to unlock
[8/1/2021, 10:34:07 AM] [homebridge-august-smart-locks] Characteristic 'Lock Target State': SET handler returned write response value, though the characteristic doesn't support write response. See https://git.io/JtMGR for more info.
[8/1/2021, 10:34:07 AM] [homebridge-august-smart-locks] Error: 
    at LockTargetState.Characteristic.characteristicWarning (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2038:105)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1663:22
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/util/once.ts:9:18
    at /homebridge/node_modules/homebridge-august-smart-locks/platform.js:542:9
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
 ```