### PR TITLE
fix warning from the characteristic 'Battery Level'

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -380,14 +380,10 @@ class AugustPlatform {
 
     Promise.all([getLock, getDetails]).then(
       function (values) {
-        var lock = values[0]
+        var lock = values[0];
         var locks = lock.info;
 
-        self.batt = values[1].battery * 100;
-        var newbatt = self.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
-        if (self.batt > 0 && self.batt <= 20) {
-          newbatt = self.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW;
-        }
+        self.batt = values[1].hasOwnProperty('battery') ? values[1].battery * 100 : false;
 
         if (!locks.bridgeID) {
           self.validData = true;
@@ -466,10 +462,10 @@ class AugustPlatform {
           newAccessory.updateReachability(true);
         }
 
-
-    if (self.batt) {
-      newAccessory.context.low = (self.batt > 20 || self.batt <= 0) ? self.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL : self.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW;
-    }
+        if (self.batt !== false) {
+            newAccessory.context.batt = self.batt;
+            newAccessory.context.low = (self.batt > 20 || self.batt <= 0) ? self.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL : self.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW;
+        }
 
         if (state) {
           var newState;


### PR DESCRIPTION
Multiple warnings in the logs like:

```
[homebridge-august-smart-locks] This plugin generated a warning from the characteristic 'Battery Level': characteristic value expected valid finite number and received "undefined" (undefined). See https://homebridge.io/w/JtMGR for more info.
```

This is caused by an undefined value at accessory.context.batt, which is not being updated.

https://github.com/blaineam/homebridge-august-smart-locks/blob/a67b573899c56270c9cfec202c92afc34e371401/platform.js#L245-L246

Stored `newAccessory.context.batt`, in addition to cleaning up some unused code for `newbatt`.